### PR TITLE
Add extendable fault target list

### DIFF
--- a/digital/testbench/README.md
+++ b/digital/testbench/README.md
@@ -107,3 +107,28 @@ Testbench execution follows standardized verification procedures:
 - Vivado Simulator support
 - Synopsys VCS compatibility
 - Open-source Icarus Verilog support
+
+## Fault Injection Utility
+
+`fault_injector.sv` provides a simple mechanism to inject transient faults into
+a user defined list of signals. The list of target signals lives in
+`include/fault_target_list.svh` where each signal is aliased to a slot in the
+`fi_targets` array. Extend this file to inject faults into additional signals.
+The injector can be instantiated or bound to the testbench and configured via
+plusargs.
+
+### Usage Example
+
+```bash
+dsim +fi_seed=42 +fi_interval=5000 \
+     -timescale 1ns/1ns -top work.dv_top -F digital/sim/processor.f
+```
+
+Parameters:
+
+- `fi_seed`       – Random seed for fault generation.
+- `fi_interval`   – Number of cycles between fault injections.
+
+The `fi_targets` array defined in `fault_target_list.svh` aliases the DUT
+signals to be affected. Edit this file to add or remove fault injection points
+and update `NUM_FAULT_TARGETS` accordingly.

--- a/digital/testbench/fault_injector.sv
+++ b/digital/testbench/fault_injector.sv
@@ -1,0 +1,76 @@
+`timescale 1ns/1ns
+
+////////////////////////////////////////////////////////////
+// Simple Fault Injector
+// Injects transient faults into selected signals using
+// force/release semantics. Target selection policy can be
+// random or round-robin. The injection interval and random
+// seed can be provided via plusargs.
+////////////////////////////////////////////////////////////
+
+module fault_injector #(
+    // 0: random, 1: round-robin
+    parameter int POLICY = 0
+) (
+    input  logic clk,
+    input  logic rst_n,
+
+    // Optional default values (overridden via plusargs)
+    input  int   seed            = 1,
+    input  int   fault_interval  = 100,
+
+    // Target signals array (open array of references)
+    ref logic [31:0] targets[]
+);
+
+    int local_seed;
+    int interval;
+    int inject_cnt;
+    int sel_idx;
+    int NUM_TARGETS;
+    logic [31:0] rand_val;
+
+    initial begin
+        if (!$value$plusargs("fi_seed=%d", local_seed)) begin
+            local_seed = seed;
+        end
+        if (!$value$plusargs("fi_interval=%d", interval)) begin
+            interval = fault_interval;
+        end
+        NUM_TARGETS = targets.size();
+        inject_cnt = 0;
+        sel_idx = 0;
+        rand_val = 0;
+        void'(std::randomize() with {`__RANDOMIZE_INIT;});
+        $display("Fault injector enabled: seed=%0d interval=%0d targets=%0d", local_seed, interval, NUM_TARGETS);
+    end
+
+    // Release all signals on reset
+    always @(negedge rst_n) begin
+        for (int i = 0; i < NUM_TARGETS; i++) begin
+            release targets[i];
+        end
+        inject_cnt = 0;
+    end
+
+    // Main injection loop
+    always @(posedge clk) begin
+        if (rst_n) begin
+            inject_cnt++;
+            if (inject_cnt >= interval) begin
+                inject_cnt = 0;
+                if (POLICY == 0) begin
+                    void'(std::randomize(sel_idx) with {sel_idx < NUM_TARGETS;});
+                end else begin
+                    sel_idx = (sel_idx + 1) % NUM_TARGETS;
+                end
+                void'(std::randomize(rand_val));
+                force targets[sel_idx] = rand_val;
+                #1;
+                release targets[sel_idx];
+            end
+        end
+    end
+
+endmodule
+

--- a/digital/testbench/include/fault_target_list.svh
+++ b/digital/testbench/include/fault_target_list.svh
@@ -1,0 +1,12 @@
+// Fault injection target list
+// Extend NUM_FAULT_TARGETS and alias statements to inject faults
+// into additional design signals.
+
+parameter int NUM_FAULT_TARGETS = 3;
+logic [31:0] fi_targets[NUM_FAULT_TARGETS];
+
+// Example target aliases
+alias fi_targets[0] = dut.Ins_Fetch.current_pc;
+alias fi_targets[1] = dut.data_mem_addr_o;
+alias fi_targets[2] = dut.Final_Result_WB_o;
+// Add more alias lines here, incrementing NUM_FAULT_TARGETS accordingly

--- a/digital/testbench/riscv_dv_tb/dv_top.sv
+++ b/digital/testbench/riscv_dv_tb/dv_top.sv
@@ -368,6 +368,20 @@ module dv_top;
         .mem_data   (tracer_if.mem_data),
         .fpu_flags  (tracer_if.fpu_flags)
     );
+
+    // Fault injector instance - target signals are defined in
+    // include/fault_target_list.svh so users can easily extend the list.
+    `include "../include/fault_target_list.svh"
+
+    fault_injector #(
+        .POLICY(0)
+    ) fi_inst (
+        .clk   (clk),
+        .rst_n (rst_n),
+        .seed  (1),
+        .fault_interval(1000),
+        .targets(fi_targets)
+    );
     
     // Test program loader
     initial begin

--- a/digital/testbench/tb_modules.f
+++ b/digital/testbench/tb_modules.f
@@ -6,5 +6,6 @@ tb_modules/tracer.v
 tb_modules/rv32i_inst_wb_adapter.sv
 tb_modules/rv32i_data_wb_adapter.sv
 tb_modules/rv32i_tracer.sv
+fault_injector.sv
 
 riscv_dv_tb/dv_top.sv


### PR DESCRIPTION
## Summary
- move fault injector target aliases into `fault_target_list.svh`
- include the target list from `dv_top.sv`
- document editing of `fault_target_list.svh` in testbench README


------
https://chatgpt.com/codex/tasks/task_e_68829d08ae40833381ad632035eca553